### PR TITLE
➕ Add support for non-Windows paths in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,11 @@ import com.ancientmc.acp.utils.*
 
 licenseimporter {
     url = 'https://raw.githubusercontent.com/ancientmc/license/master/LICENSE'
-    output = file(project.projectDir.path + "\\LICENSE")
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        output = file(project.projectDir.path + "\\LICENSE")
+    } else {
+        output = file(project.projectDir.path + "/LICENSE")
+    }
 }
 
 acp {
@@ -51,7 +55,11 @@ acp {
 
 modtools {
     loader = 'risugami'
-    diffPatchesDir = project.buildDir.absolutePath + '\\modding\\patches\\diff'
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        diffPatchesDir = project.buildDir.absolutePath + '\\modding\\patches\\diff'
+    } else {
+        diffPatchesDir = project.buildDir.absolutePath + '/modding/patches/diff'
+    }
     modName = 'mod'
 }
 
@@ -75,10 +83,18 @@ compileJava {
 
 jar {
     archiveBaseName = 'interm'
-    exclude ('acp\\')
-    from(zipTree(file(Paths.EXTRA_JAR))) {
-        include('com\\')
-        include('paulscode\\')
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        exclude ('acp\\')
+        from(zipTree(file(Paths.EXTRA_JAR))) {
+            include('com\\')
+            include('paulscode\\')
+        }
+    } else {
+        exclude ('acp/')
+        from(zipTree(file(Paths.EXTRA_JAR))) {
+            include('com/')
+            include('paulscode/')
+        }
     }
 }
 
@@ -86,10 +102,18 @@ FileFilter tempFilter = (File file) -> !file.name.equals(MC_VERSION + '.jar') &&
 FileFilter runFilter = (File file1) -> !file1.name.contains('resources') && !file1.name.contains('bin')
 
 clean {
-    delete(file("${Paths.DIR_SRC}\\net\\"))
-    delete(file("${Paths.DIR_SRC}\\risugami\\"))
     delete(file(Paths.DIR_ORIGINAL_SRC))
-    if(file("src\\main\\resources\\").exists()) delete(file("src\\main\\resources\\").listFiles())
-    if(file("cfg\\temp\\").exists()) delete(file("cfg\\temp\\").listFiles(tempFilter))
-    if(file("run\\").exists()) delete(file("run").listFiles(runFilter))
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        delete(file("${Paths.DIR_SRC}\\net\\"))
+        delete(file("${Paths.DIR_SRC}\\risugami\\"))
+        if(file("src\\main\\resources\\").exists()) delete(file("src\\main\\resources\\").listFiles())
+        if(file("cfg\\temp\\").exists()) delete(file("cfg\\temp\\").listFiles(tempFilter))
+        if(file("run\\").exists()) delete(file("run").listFiles(runFilter))
+    } else {
+        delete(file("${Paths.DIR_SRC}/net/"))
+        delete(file("${Paths.DIR_SRC}/risugami/"))
+        if(file("src/main/resources/").exists()) delete(file("src/main/resources/").listFiles())
+        if(file("cfg/temp/").exists()) delete(file("cfg/temp/").listFiles(tempFilter))
+        if(file("run/").exists()) delete(file("run").listFiles(runFilter))
+    }
 }


### PR DESCRIPTION
Fixed `build.gradle` to support slash paths not in Windows.